### PR TITLE
Fix is_initializer_list_constructible_v.

### DIFF
--- a/include/concepts/operations/is_constructible_v.hpp
+++ b/include/concepts/operations/is_constructible_v.hpp
@@ -3,8 +3,11 @@
 
 # include <new>
 # include <type_traits>
+
 # include "../../partial_apply.hpp"
 # include "../../type_tuple.hpp"
+# include "../../bool_constant.hpp"
+
 # include "def_convenient_macros.hpp"
 
 namespace nxwheels {
@@ -13,6 +16,10 @@ namespace nxwheels {
 
 DEF_TMP using direct_construct_t          = decltype( new T(declval<Args>()...) );
 DEF_TMP using list_construct_t            = decltype( new T{declval<Args>()...} );
+/*!
+ * This is just a naive emulation of initializer_list initialization.
+ * You need to manually filter out the situation when default construct, cp/mv is actually expected.
+ */
 DEF_TMP using initialier_list_construct_t = decltype( new T({declval<Args>()...}) );
 
 DEF_TMP VAR is_direct_constructible_v = is_detected_v<direct_construct_t, T, Args...>;
@@ -33,11 +40,18 @@ DEF_TMP VAR is_nothrow_list_constructible_v = [] {
         return false;
 }();
 
-DEF_TMP VAR is_initializer_list_constructible_v = is_detected_v<initialier_list_construct_t, T, Args...>;
-DEF_TMP VAR is_nothrow_initializer_list_constructible_impl_v = noexcept( new (nullptr) T({declval<Args>()...}) );
+DEF_TMP            struct is_initializer_list_constructible             : bool_constant<is_detected_v<initialier_list_construct_t, T, Args...>> {};
+template <class T> struct is_initializer_list_constructible<T>          : false_type {};
+template <class T> struct is_initializer_list_constructible<T, const T&>: false_type {};
+template <class T> struct is_initializer_list_constructible<T, T&&>     : false_type {};
+template <class T> struct is_initializer_list_constructible<T, T>       : false_type {};
+template <class T> struct is_initializer_list_constructible<T, T&>      : false_type {};
+DEF_TMP VAR is_initializer_list_constructible_v = is_initializer_list_constructible<T, Args...>::value;
+
+// There is no separate is_nothrow_initializer_list_constructible_impl_v due to the fact that you can use is_nothrow_list_constructible_impl_v.
 DEF_TMP VAR is_nothrow_initializer_list_constructible_v = []{
     if constexpr(is_initializer_list_constructible_v<T, Args...>)
-        return is_nothrow_initializer_list_constructible_impl_v<T, Args...>;
+        return is_nothrow_list_constructible_impl_v<T, Args...>;
     else
         return false;
 }();
@@ -67,7 +81,7 @@ DEF_TMP VAR is_nothrow_move_constructible_v      = is_nothrow_direct_constructib
 
 DEF_CLASS_WRAPPER(direct_constructible);
 DEF_CLASS_WRAPPER(list_constructible);
-DEF_CLASS_WRAPPER(initializer_list_constructible);
+_DEF_CLASS_WRAPPER(nothrow_initializer_list_constructible);
 DEF_CLASS_WRAPPER(default_constructible);
 DEF_CLASS_WRAPPER(copy_constructible);
 DEF_CLASS_WRAPPER(move_constructible);

--- a/test/concepts/operations/test_is_constructible_v.cc
+++ b/test/concepts/operations/test_is_constructible_v.cc
@@ -91,15 +91,16 @@ int main() {
 
     // Test is_initializer_list_constructible_v.
     static_assert(!is_initializer_list_constructible_v<int, int>);
+    static_assert(!is_initializer_list_constructible_v<std::initializer_list<int>>);
+    static_assert(!is_initializer_list_constructible_v<initializer_list_constructible>);
+    static_assert(!is_initializer_list_constructible_v<initializer_list_constructible, initializer_list_constructible>);
 
-    static_assert(is_initializer_list_constructible_v<std::initializer_list<int>>);
     static_assert(is_initializer_list_constructible_v<std::initializer_list<int>, int, char>);
-    static_assert(is_initializer_list_constructible_v<initializer_list_constructible>);
     static_assert(is_initializer_list_constructible_v<initializer_list_constructible, int, char>);
 
     // Test is_nothrow_initializer_list_constructible_v.
     static_assert(!is_nothrow_initializer_list_constructible_v<int, int>);
+    static_assert(!is_nothrow_initializer_list_constructible_v<nothrow_initializer_list_constructible>);
 
-    static_assert(is_nothrow_initializer_list_constructible_v<nothrow_initializer_list_constructible>);
     static_assert(is_nothrow_initializer_list_constructible_v<nothrow_initializer_list_constructible, int, char>);
 }


### PR DESCRIPTION
 1. Adapt include sequence to comply with the requirement in README.md.
 2. Add workaround to is_initializer_list_constructible_v to prevent
default/cp/mv construction to be interpreted as initializer_list
initialization.
 3. Remove is_nothrow_initializer_list_constructible_impl_v.