### PR TITLE
Add CONCEPT_T.

### DIFF
--- a/include/bool_constant.hpp
+++ b/include/bool_constant.hpp
@@ -1,10 +1,15 @@
 #ifndef __nobodyxu_concept_check_bool_constant_HPP__
 # define __nobodyxu_concept_check_bool_constant_HPP__
 
+# include "def_convenient_macros.hpp"
+
 namespace nxwheels {
-template <bool _value> struct bool_constant { constexpr const inline static bool value = _value; };
+template <bool _value> struct bool_constant { CONCEPT_T value = _value; };
 
 using true_type = bool_constant<true>;
 using false_type = bool_constant<false>;
 } /* nxwheels */
+
+# include "undef_convenient_macros.hpp"
+
 #endif

--- a/include/concepts/def_convenient_macros.hpp
+++ b/include/concepts/def_convenient_macros.hpp
@@ -1,15 +1,14 @@
 #include "../enable_if.hpp"
 
-#ifndef VAR
-# define VAR constexpr const static inline bool
-#endif
+#include "../def_convenient_macros.hpp"
+
 
 #ifndef TP1
 # define TP1 template <class T>
 #endif
 
 #ifndef DEF_CONCEPT1
-# define DEF_CONCEPT1 TP1 VAR
+# define DEF_CONCEPT1 TP1 CONCEPT_T
 #endif
 
 #ifndef DEF_CHECK1

--- a/include/concepts/has_valid_iterator_traits_v.hpp
+++ b/include/concepts/has_valid_iterator_traits_v.hpp
@@ -10,10 +10,12 @@
 # include "is_nullable_pointer_v.hpp"
 # include "is_arithmetic_v.hpp"
 
+# include "def_convenient_macros.hpp"
+
 namespace nxwheels {
 # define TRAITS(MEMBER_NAME) typename std::iterator_traits<T>:: MEMBER_NAME
-template <class T>
-constexpr const static inline bool has_valid_iterator_traits_v = []{
+
+DEF_CONCEPT1 has_valid_iterator_traits_v = []{
     if constexpr(has_member_value_type_v<std::iterator_traits<T>>)
         return !std::is_void              <TRAITS(value_type)>{}()                &&
                is_implicitly_convertible_v<TRAITS(reference), TRAITS(value_type)> &&
@@ -23,6 +25,9 @@ constexpr const static inline bool has_valid_iterator_traits_v = []{
     else
         return false;
 }();
+
 # undef TRAITS
 } /* nxwheels */
+
+# include "undef_convenient_macros.hpp"
 #endif

--- a/include/concepts/is_builtin_nonmember_pointer.hpp
+++ b/include/concepts/is_builtin_nonmember_pointer.hpp
@@ -2,11 +2,15 @@
 # define __nobodyxu_concept_check_concepts_is_builtin_nonmember_pointer_HPP__
 
 # include "../bool_constant.hpp"
+# include "def_convenient_macros.hpp"
 
 namespace nxwheels {
 template <class T> struct is_builtin_nonmember_pointer:     false_type {};
 template <class T> struct is_builtin_nonmember_pointer<T*>: true_type {};
 
-template <class T> constexpr const static inline bool is_builtin_nonmember_pointer_v = is_builtin_nonmember_pointer<T>::value;
+DEF_CONCEPT1 is_builtin_nonmember_pointer_v = is_builtin_nonmember_pointer<T>::value;
 } /* nxwheels */
+
+# include "undef_convenient_macros.hpp"
+
 #endif

--- a/include/concepts/is_builtin_pointer.hpp
+++ b/include/concepts/is_builtin_pointer.hpp
@@ -6,9 +6,10 @@
 # include "is_builtin_nonmember_pointer.hpp"
 # include "is_member_pointer.hpp"
 
+# include "def_convenient_macros.hpp"
+
 namespace nxwheels {
-template <class T>
-constexpr const static inline bool is_builtin_pointer_v = is_builtin_nonmember_pointer_v<T> || is_member_pointer_v<T>;
+DEF_CONCEPT1 is_builtin_pointer_v = is_builtin_nonmember_pointer_v<T> || is_member_pointer_v<T>;
 
 template <class T>
 struct pointed_to_by_pointer {};
@@ -20,4 +21,7 @@ struct pointed_to_by_pointer<P T::*> { using type = P; };
 template <class T>
 using pointed_to_by_pointer_t = typename pointed_to_by_pointer<T>::type;
 } /* nxwheels */
+
+# include "undef_convenient_macros.hpp"
+
 #endif

--- a/include/concepts/is_class_or_union_v.hpp
+++ b/include/concepts/is_class_or_union_v.hpp
@@ -2,9 +2,14 @@
 # define __nobodyxu_concept_check_concepts_is_class_or_union_v_HPP__
 
 # include "../detector_core.hpp"
+# include "def_convenient_macros.hpp"
 
 namespace nxwheels {
 template <class T, class pointed_t = int> using member_pointer_t = pointed_t T::*;
-template <class T> constexpr const static inline bool is_class_or_union_v = is_detected_v<member_pointer_t, T>;
+
+template <class T> CONCEPT_T is_class_or_union_v = is_detected_v<member_pointer_t, T>;
 } /* nxwheels */
+
+# include "undef_convenient_macros.hpp"
+
 #endif

--- a/include/concepts/is_iterator_core.hpp
+++ b/include/concepts/is_iterator_core.hpp
@@ -27,31 +27,30 @@ DEF_CONCEPT1 is_InputIterator_core_v         = is_Iterator_core_v<T> &&
 DEF_CONCEPT1 is_ForwardIterator_core_v       = is_InputIterator_core_v<T>  && is_default_constructible_v<T>;
 DEF_CONCEPT1 is_BidirectionalIterator_core_v = is_ForwardIterator_core_v<T> && is_self_decrementable_v<T&>;
 
-template <class T>
-VAR is_RandomAccessIterator_core_impl_comp_req_v = is_GreaterEqualCompareable_v<T>                            &&
-                                                   is_GreaterThanCompareable_v<T>                             &&
-                                                   is_LessEqualCompareable_v<T>                               &&
-                                                   is_LessThanCompareable_v<T>;
+DEF_CONCEPT1 is_RandomAccessIterator_core_impl_comp_req_v = is_GreaterEqualCompareable_v<T>                            &&
+                                                            is_GreaterThanCompareable_v<T>                             &&
+                                                            is_LessEqualCompareable_v<T>                               &&
+                                                            is_LessThanCompareable_v<T>;
 template <class T, class diff_t, class ref>
-VAR is_RandomAccessIterator_core_impl_other_req_v = /* arithmetic op requirement */
-                                          /* arithmetic assignment op */
-                                          is_addition_assignmentable_v<T&, diff_t>                    &&
-                                          is_subtraction_assignmentable_v<T&, diff_t>                 &&
-                                          /* nonassignment op */
-                                          is_additionable_v<T, diff_t>                               &&
-                                          is_implicitly_convertible_v<additioned_ret_t<diff_t, T>, T> &&
-                                          is_subtractionable_v<T, diff_t>                            &&
-                                          is_implicitly_convertible_v<subtractioned_ret_t<T, T>, diff_t> &&
-                                          /* access requirement */
-                                          is_subscriptable_v<T, diff_t>                              &&
-                                          /* convertion requirement */
-                                          is_implicitly_convertible_v<subscripted_t<T, diff_t>, ref>;
+CONCEPT_T is_RandomAccessIterator_core_impl_other_req_v = /* arithmetic op requirement */
+                                                          /* arithmetic assignment op */
+                                                          is_addition_assignmentable_v<T&, diff_t>                    &&
+                                                          is_subtraction_assignmentable_v<T&, diff_t>                 &&
+                                                          /* nonassignment op */
+                                                          is_additionable_v<T, diff_t>                               &&
+                                                          is_implicitly_convertible_v<additioned_ret_t<diff_t, T>, T> &&
+                                                          is_subtractionable_v<T, diff_t>                            &&
+                                                          is_implicitly_convertible_v<subtractioned_ret_t<T, T>, diff_t> &&
+                                                          /* access requirement */
+                                                          is_subscriptable_v<T, diff_t>                              &&
+                                                          /* convertion requirement */
+                                                          is_implicitly_convertible_v<subscripted_t<T, diff_t>, ref>;
 
 # define TRAITS(NAME) typename std::iterator_traits<T>:: NAME
 template <class T, class diff_t = TRAITS(difference_type), class ref = TRAITS(reference)>
-VAR is_RandomAccessIterator_core_v = is_BidirectionalIterator_core_v<T>              &&
-                                     is_RandomAccessIterator_core_impl_comp_req_v<T> &&
-                                     is_RandomAccessIterator_core_impl_other_req_v<T, diff_t, ref>;
+CONCEPT_T is_RandomAccessIterator_core_v = is_BidirectionalIterator_core_v<T>              &&
+                                           is_RandomAccessIterator_core_impl_comp_req_v<T> &&
+                                           is_RandomAccessIterator_core_impl_other_req_v<T, diff_t, ref>;
 # undef TRAITS
 } /* nxwheels */
 

--- a/include/concepts/is_member_pointer.hpp
+++ b/include/concepts/is_member_pointer.hpp
@@ -4,6 +4,8 @@
 # include "../bool_constant.hpp"
 # include "../function_traits.hpp"
 
+# include "def_convenient_macros.hpp"
+
 namespace nxwheels {
 template <class T>          struct is_member_pointer:         false_type {};
 template <class P, class T> struct is_member_pointer<P T::*>: true_type {
@@ -11,21 +13,24 @@ template <class P, class T> struct is_member_pointer<P T::*>: true_type {
     using class_belonged_to_t = T;
 };
 
-template <class T> constexpr const static inline bool is_member_pointer_v = is_member_pointer<T>::value;
-template <class T> using pointed_to_by_member_pointer_t     = typename is_member_pointer<T>::pointed_t;
-template <class T> using class_member_pointer_belonged_to_t = typename is_member_pointer<T>::class_belonged_to_t;
+TP1 CONCEPT_T is_member_pointer_v = is_member_pointer<T>::value;
+TP1 using pointed_to_by_member_pointer_t     = typename is_member_pointer<T>::pointed_t;
+TP1 using class_member_pointer_belonged_to_t = typename is_member_pointer<T>::class_belonged_to_t;
 
-template <class T> constexpr const static inline bool is_member_function_pointer_v = [] {
+DEF_CONCEPT1 is_member_function_pointer_v = [] {
     if constexpr(is_member_pointer_v<T>)
         return is_function_v<pointed_to_by_member_pointer_t<T>>;
     else
         return false;
 }();
-template <class T> constexpr const static inline bool is_member_object_pointer_v = [] {
+DEF_CONCEPT1 is_member_object_pointer_v = [] {
     if constexpr(is_member_pointer_v<T>)
         return !is_function_v<pointed_to_by_member_pointer_t<T>>;
     else
         return false;
 }();
 } /* nxwheels */
+
+# include "undef_convenient_macros.hpp"
+
 #endif

--- a/include/concepts/is_pointable_v.hpp
+++ b/include/concepts/is_pointable_v.hpp
@@ -2,9 +2,13 @@
 # define __nobodyxu_concept_check_concepts_type_properties_is_pointable_v_HPP__
 
 # include "../detector_core.hpp"
+# include "def_convenient_macros.hpp"
 
 namespace nxwheels {
-template <class T> using pointer_t = T*;
-template <class T> constexpr const static inline bool is_pointable_v = is_detected_v<pointer_t, T>;
+TP1 using pointer_t = T*;
+TP1 CONCEPT_T is_pointable_v = is_detected_v<pointer_t, T>;
 } /* nxwheels */
+
+# include "undef_convenient_macros.hpp"
+
 #endif

--- a/include/concepts/is_referenceable_v.hpp
+++ b/include/concepts/is_referenceable_v.hpp
@@ -2,12 +2,16 @@
 # define __nobodyxu_concept_check_concepts_type_properties_is_referenceable_v_HPP__
 
 # include "../detector_core.hpp"
+# include "def_convenient_macros.hpp"
 
 namespace nxwheels {
-template <class T> using lvalue_ref_t = T&;
+TP1 using lvalue_ref_t = T&;
 /*!
  * is_referenceable_v tests whether T& is valid.
  */
-template <class T> constexpr const static inline bool is_referenceable_v = is_detected_v<lvalue_ref_t, T>;
+TP1 CONCEPT_T is_referenceable_v = is_detected_v<lvalue_ref_t, T>;
 } /* nxwheels */
+
+# include "undef_convenient_macros.hpp"
+
 #endif

--- a/include/concepts/is_same.hpp
+++ b/include/concepts/is_same.hpp
@@ -3,6 +3,7 @@
 
 # include "../bool_constant.hpp"
 # include "../enable_if.hpp"
+# include "def_convenient_macros.hpp"
 
 namespace nxwheels {
 /*!
@@ -20,10 +21,13 @@ template <class T> struct is_same_impl<void, T, T, T>: true_type {};
 
 template <class ...Args> struct is_same: is_same_impl<void, Args...> {};
 
-template <class ...Args> constexpr const static inline bool is_same_v = is_same<Args...>::value;
+template <class ...Args> CONCEPT_T is_same_v = is_same<Args...>::value;
 
 template <class ...Args> constexpr void assert_same_type() noexcept { static_assert(is_same_v<Args...>, "They are not the same type!"); }
 
 template <class ...Args> constexpr void assert_not_same_type() noexcept { static_assert(!is_same_v<Args...>, "They are the same type!"); }
 } /* nxwheels */
+
+# include "undef_convenient_macros.hpp"
+
 #endif

--- a/include/concepts/operations/def_convenient_macros.hpp
+++ b/include/concepts/operations/def_convenient_macros.hpp
@@ -9,12 +9,14 @@
 # include "../../detector_v.hpp"
 #endif
 
+# include "../../def_convenient_macros.hpp"
+
 #ifndef DEF_UN_CHECK
 # define DEF_UN_CHECK(NAME, OP)                                                                                 \
 template <class T> using NAME ##ed_ret_t = decltype( OP declval<T>() );                                             \
-template <class T> constexpr const static inline bool is_## NAME ##able_v = is_detected_v<NAME ##ed_ret_t, T>;      \
-template <class T> constexpr const static inline bool is_nothrow_## NAME ##able_impl_v = noexcept( OP declval<T>() );\
-template <class T> constexpr const static inline bool is_nothrow_## NAME ##able_v = []{                              \
+template <class T> CONCEPT_T is_## NAME ##able_v = is_detected_v<NAME ##ed_ret_t, T>;      \
+template <class T> CONCEPT_T is_nothrow_## NAME ##able_impl_v = noexcept( OP declval<T>() );\
+template <class T> CONCEPT_T is_nothrow_## NAME ##able_v = []{                              \
     if constexpr(is_## NAME ##able_v<T>)                                                                             \
         return is_nothrow_## NAME ##able_impl_v<T>;                                                                  \
     else                                                                                                             \
@@ -25,9 +27,9 @@ template <class T> constexpr const static inline bool is_nothrow_## NAME ##able_
 #ifndef DEF_BIN_CHECK
 # define DEF_BIN_CHECK(NAME, OP)                                                                                                          \
 template <class T1, class T2> using NAME ##ed_ret_t = decltype( declval<T1>() OP declval<T2>() );                                             \
-template <class T1, class T2> constexpr const static inline bool is_## NAME ##able_v = is_detected_v<NAME ##ed_ret_t, T1, T2>;                \
-template <class T1, class T2> constexpr const static inline bool is_nothrow_## NAME ##able_impl_v = noexcept( declval<T1>() OP declval<T2>() );\
-template <class T1, class T2> constexpr const static inline bool is_nothrow_## NAME ##able_v = []{                                             \
+template <class T1, class T2> CONCEPT_T is_## NAME ##able_v = is_detected_v<NAME ##ed_ret_t, T1, T2>;                \
+template <class T1, class T2> CONCEPT_T is_nothrow_## NAME ##able_impl_v = noexcept( declval<T1>() OP declval<T2>() );\
+template <class T1, class T2> CONCEPT_T is_nothrow_## NAME ##able_v = []{                                             \
     if constexpr(is_## NAME ##able_v<T1, T2>)                                                                                                  \
         return is_nothrow_## NAME ##able_impl_v<T1, T2>;                                                                                       \
     else                                                                                                                                       \
@@ -38,9 +40,9 @@ template <class T1, class T2> constexpr const static inline bool is_nothrow_## N
 #ifndef DEF_UN_IMP_CONVERT_CHECK
 # define DEF_UN_IMP_CONVERT_CHECK(NAME, OP, RET_T)                                                                                 \
 template <class T> using NAME ##ed_ret_t = decltype( OP declval<T>() );                                             \
-template <class T> constexpr const static inline bool is_## NAME ##able_v = is_detected_implicitly_convertible_v<RET_T, NAME ##ed_ret_t, T>;      \
-template <class T> constexpr const static inline bool is_nothrow_## NAME ##able_impl_v = noexcept( OP declval<T>() );\
-template <class T> constexpr const static inline bool is_nothrow_## NAME ##able_v = []{                              \
+template <class T> CONCEPT_T is_## NAME ##able_v = is_detected_implicitly_convertible_v<RET_T, NAME ##ed_ret_t, T>;      \
+template <class T> CONCEPT_T is_nothrow_## NAME ##able_impl_v = noexcept( OP declval<T>() );\
+template <class T> CONCEPT_T is_nothrow_## NAME ##able_v = []{                              \
     if constexpr(is_## NAME ##able_v<T>)                                                                             \
         return is_nothrow_## NAME ##able_impl_v<T>;                                                                  \
     else                                                                                                             \
@@ -51,9 +53,9 @@ template <class T> constexpr const static inline bool is_nothrow_## NAME ##able_
 #ifndef DEF_BIN_IMP_CONVERT_CHECK
 # define DEF_BIN_IMP_CONVERT_CHECK(NAME, OP, RET_T)                                                                                                          \
 template <class T1, class T2> using NAME ##ed_ret_t = decltype( declval<T1>() OP declval<T2>() );                                             \
-template <class T1, class T2> constexpr const static inline bool is_## NAME ##able_v = is_detected_implicitly_convertible_v<RET_T, NAME ##ed_ret_t, T1, T2>;                \
-template <class T1, class T2> constexpr const static inline bool is_nothrow_## NAME ##able_impl_v = noexcept( declval<T1>() OP declval<T2>() );\
-template <class T1, class T2> constexpr const static inline bool is_nothrow_## NAME ##able_v = []{                                             \
+template <class T1, class T2> CONCEPT_T is_## NAME ##able_v = is_detected_implicitly_convertible_v<RET_T, NAME ##ed_ret_t, T1, T2>;                \
+template <class T1, class T2> CONCEPT_T is_nothrow_## NAME ##able_impl_v = noexcept( declval<T1>() OP declval<T2>() );\
+template <class T1, class T2> CONCEPT_T is_nothrow_## NAME ##able_v = []{                                             \
     if constexpr(is_## NAME ##able_v<T1, T2>)                                                                                                  \
         return is_nothrow_## NAME ##able_impl_v<T1, T2>;                                                                                       \
     else                                                                                                                                       \

--- a/include/concepts/operations/is_callable_core.hpp
+++ b/include/concepts/operations/is_callable_core.hpp
@@ -7,14 +7,13 @@
 
 namespace nxwheels {
 # define DEF_TMP template <class T, class ...Args>
-# define VAR constexpr const static inline bool
 
 DEF_TMP using called_ret_t = decltype( (declval<T>())(decl_as<Args>()...) );
 DEF_TMP using is_callable = is_detected<called_ret_t, T, Args...>;
 
-DEF_TMP VAR is_callable_v = is_detected_v<called_ret_t, T, Args...>;
-DEF_TMP VAR is_nothrow_callable_impl_v = noexcept( (declval<T>())(decl_as<Args>()...) );
-DEF_TMP VAR is_nothrow_callable_v = []{
+DEF_TMP CONCEPT_T is_callable_v = is_detected_v<called_ret_t, T, Args...>;
+DEF_TMP CONCEPT_T is_nothrow_callable_impl_v = noexcept( (declval<T>())(decl_as<Args>()...) );
+DEF_TMP CONCEPT_T is_nothrow_callable_v = []{
     if constexpr(is_callable_v<T, Args...>)
         return is_nothrow_callable_impl_v<T, Args...>;
     else

--- a/include/concepts/operations/is_callable_v.hpp
+++ b/include/concepts/operations/is_callable_v.hpp
@@ -5,8 +5,13 @@
 # include "is_callable_core.hpp"
 # include "is_convertible_v.hpp"
 
+# include "../../def_convenient_macros.hpp"
+
 namespace nxwheels {
-template <class T2, class T, class ...Args> constexpr const static inline bool is_callable_exact_v                  = is_same_v<callable_result_t<T, Args...>, T2>;
-template <class To, class T, class ...Args> constexpr const static inline bool is_callable_implicitly_convertible_v = is_implicitly_convertible_v<callable_result_t<T, Args...>, To>;
+template <class T2, class T, class ...Args> CONCEPT_T is_callable_exact_v                  = is_same_v<callable_result_t<T, Args...>, T2>;
+template <class To, class T, class ...Args> CONCEPT_T is_callable_implicitly_convertible_v = is_implicitly_convertible_v<callable_result_t<T, Args...>, To>;
 } /* nxwheels */
+
+# include "../../undef_convenient_macros.hpp"
+
 #endif

--- a/include/concepts/operations/is_comparable_v.hpp
+++ b/include/concepts/operations/is_comparable_v.hpp
@@ -14,8 +14,8 @@ DEF_BIN_IMP_CONVERT_CHECK(GreaterEqualCompare, >=, bool);
 
 namespace nxwheels {
 # define DEF_CHECK(NAME)                                                                                                                                           \
-template <class T1, class T2 = T1> constexpr const static inline bool is_## NAME ##able_v = impl::is_## NAME ##able_v<T1, T2> && impl::is_## NAME ##able_v<T2, T1>;\
-template <class T1, class T2 = T1> constexpr const static inline bool is_nothrow_## NAME ##able_v = impl::is_nothrow_## NAME ##able_v<T1, T2> && impl::is_nothrow_## NAME ##able_v<T2, T1>
+template <class T1, class T2 = T1> CONCEPT_T is_## NAME ##able_v = impl::is_## NAME ##able_v<T1, T2> && impl::is_## NAME ##able_v<T2, T1>;\
+template <class T1, class T2 = T1> CONCEPT_T is_nothrow_## NAME ##able_v = impl::is_nothrow_## NAME ##able_v<T1, T2> && impl::is_nothrow_## NAME ##able_v<T2, T1>
 
 DEF_CHECK(EqualityCompare);
 DEF_CHECK(InEqualityCompare);

--- a/include/concepts/operations/is_constructible_v.hpp
+++ b/include/concepts/operations/is_constructible_v.hpp
@@ -11,7 +11,6 @@
 
 namespace nxwheels {
 # define DEF_TMP template <class T, class ...Args>
-# define VAR constexpr const static inline bool
 
 DEF_TMP using direct_construct_t          = decltype( new T(declval<Args>()...) );
 DEF_TMP using list_construct_t            = decltype( new T{declval<Args>()...} );
@@ -21,18 +20,18 @@ DEF_TMP using list_construct_t            = decltype( new T{declval<Args>()...} 
  */
 DEF_TMP using initialier_list_construct_t = decltype( new T({declval<Args>()...}) );
 
-DEF_TMP VAR is_direct_constructible_v = is_detected_v<direct_construct_t, T, Args...>;
-DEF_TMP VAR is_nothrow_direct_constructible_impl_v = noexcept( new (nullptr) T(declval<Args>()...) );
-DEF_TMP VAR is_nothrow_direct_constructible_v = [] {
+DEF_TMP CONCEPT_T is_direct_constructible_v = is_detected_v<direct_construct_t, T, Args...>;
+DEF_TMP CONCEPT_T is_nothrow_direct_constructible_impl_v = noexcept( new (nullptr) T(declval<Args>()...) );
+DEF_TMP CONCEPT_T is_nothrow_direct_constructible_v = [] {
     if constexpr(is_direct_constructible_v<T, Args...>)
         return is_nothrow_direct_constructible_impl_v<T, Args...>;
     else
         return false;
 }();
 
-DEF_TMP VAR is_list_constructible_v = is_detected_v<list_construct_t, T, Args...>;
-DEF_TMP VAR is_nothrow_list_constructible_impl_v = noexcept( new (nullptr) T{declval<Args>()...} );
-DEF_TMP VAR is_nothrow_list_constructible_v = [] {
+DEF_TMP CONCEPT_T is_list_constructible_v = is_detected_v<list_construct_t, T, Args...>;
+DEF_TMP CONCEPT_T is_nothrow_list_constructible_impl_v = noexcept( new (nullptr) T{declval<Args>()...} );
+DEF_TMP CONCEPT_T is_nothrow_list_constructible_v = [] {
     if constexpr(is_list_constructible_v<T, Args...>)
         return is_nothrow_list_constructible_impl_v<T, Args...>;
     else
@@ -45,10 +44,10 @@ template <class T> struct is_initializer_list_constructible<T, const T&>: false_
 template <class T> struct is_initializer_list_constructible<T, T&&>     : false_type {};
 template <class T> struct is_initializer_list_constructible<T, T>       : false_type {};
 template <class T> struct is_initializer_list_constructible<T, T&>      : false_type {};
-DEF_TMP VAR is_initializer_list_constructible_v = is_initializer_list_constructible<T, Args...>::value;
+DEF_TMP CONCEPT_T is_initializer_list_constructible_v = is_initializer_list_constructible<T, Args...>::value;
 
 // There is no separate is_nothrow_initializer_list_constructible_impl_v due to the fact that you can use is_nothrow_list_constructible_impl_v.
-DEF_TMP VAR is_nothrow_initializer_list_constructible_v = []{
+DEF_TMP CONCEPT_T is_nothrow_initializer_list_constructible_v = []{
     if constexpr(is_initializer_list_constructible_v<T, Args...>)
         return is_nothrow_list_constructible_impl_v<T, Args...>;
     else
@@ -60,19 +59,18 @@ DEF_TMP VAR is_nothrow_initializer_list_constructible_v = []{
 # define DEF_TMP template <class T>
 
 // Define of shortcut of often used concepts.
-DEF_TMP VAR is_default_constructible_v              = is_direct_constructible_v<T>;
-DEF_TMP VAR is_nothrow_default_constructible_impl_v = is_nothrow_direct_constructible_impl_v<T>;
-DEF_TMP VAR is_nothrow_default_constructible_v      = is_nothrow_direct_constructible_v<T>;
+DEF_TMP CONCEPT_T is_default_constructible_v              = is_direct_constructible_v<T>;
+DEF_TMP CONCEPT_T is_nothrow_default_constructible_impl_v = is_nothrow_direct_constructible_impl_v<T>;
+DEF_TMP CONCEPT_T is_nothrow_default_constructible_v      = is_nothrow_direct_constructible_v<T>;
 
-DEF_TMP VAR is_copy_constructible_v              = is_direct_constructible_v<T, const T&>;
-DEF_TMP VAR is_nothrow_copy_constructible_impl_v = is_nothrow_direct_constructible_impl_v<T, const T&>;
-DEF_TMP VAR is_nothrow_copy_constructible_v      = is_nothrow_direct_constructible_v<T, const T&>;
+DEF_TMP CONCEPT_T is_copy_constructible_v              = is_direct_constructible_v<T, const T&>;
+DEF_TMP CONCEPT_T is_nothrow_copy_constructible_impl_v = is_nothrow_direct_constructible_impl_v<T, const T&>;
+DEF_TMP CONCEPT_T is_nothrow_copy_constructible_v      = is_nothrow_direct_constructible_v<T, const T&>;
 
-DEF_TMP VAR is_move_constructible_v              = is_direct_constructible_v<T, T&&>;
-DEF_TMP VAR is_nothrow_move_constructible_impl_v = is_nothrow_direct_constructible_impl_v<T, T&&>;
-DEF_TMP VAR is_nothrow_move_constructible_v      = is_nothrow_direct_constructible_v<T, T&&>;
+DEF_TMP CONCEPT_T is_move_constructible_v              = is_direct_constructible_v<T, T&&>;
+DEF_TMP CONCEPT_T is_nothrow_move_constructible_impl_v = is_nothrow_direct_constructible_impl_v<T, T&&>;
+DEF_TMP CONCEPT_T is_nothrow_move_constructible_v      = is_nothrow_direct_constructible_v<T, T&&>;
 
-# undef VAR
 # undef DEF_TMP
 
 # define _DEF_CLASS_WRAPPER(NAME) template <class T, class ...Args> struct is_## NAME : bool_constant<is_## NAME ##_v<T, Args...>> {}

--- a/include/concepts/operations/is_convertible_v.hpp
+++ b/include/concepts/operations/is_convertible_v.hpp
@@ -9,10 +9,10 @@
 # undef  DONT_USE_DETECTOR_V
 
 namespace nxwheels {
-template <class T> constexpr const static inline auto lambda_for_implicit_conversion = [](T) noexcept {};
+template <class T> CONSTEXPR_GLOBAL_VAR auto lambda_for_implicit_conversion = [](T) noexcept {};
 template <class T> using lambda_for_implicit_conversion_t = decltype(lambda_for_implicit_conversion<T>);
 
-template <class From, class To> constexpr const static inline bool is_implicitly_convertible_v = []{
+template <class From, class To> CONCEPT_T is_implicitly_convertible_v = []{
     if constexpr(is_same_v<To, void>)
         return true;
     else
@@ -20,8 +20,8 @@ template <class From, class To> constexpr const static inline bool is_implicitly
 }();
 
 template <class From, class To>
-constexpr const static inline bool is_nothrow_implicitly_convertible_impl_v = noexcept( lambda_for_implicit_conversion<To>(declval<From>()) );
-template <class From, class To> constexpr const static inline bool is_nothrow_implicitly_convertible_v = []{
+CONCEPT_T is_nothrow_implicitly_convertible_impl_v = noexcept( lambda_for_implicit_conversion<To>(declval<From>()) );
+template <class From, class To> CONCEPT_T is_nothrow_implicitly_convertible_v = []{
     if constexpr(is_implicitly_convertible_v<From, To>)
         return is_nothrow_implicitly_convertible_impl_v<From, To>;
     else

--- a/include/concepts/operations/is_dereferenceable_v.hpp
+++ b/include/concepts/operations/is_dereferenceable_v.hpp
@@ -11,7 +11,7 @@ DEF_UN_CHECK(dereference, *);
 
 template <class T> using dereferenced_or_nonsuch_t = detected_or_t<nonsuch, dereferenceed_ret_t, T>;
 
-# define DEF_CONCEPT template <class T, class Ret> constexpr const static inline bool
+# define DEF_CONCEPT template <class T, class Ret> CONCEPT_T
 
 DEF_CONCEPT is_exact_dereferenceable_v         = is_same_v<dereferenced_or_nonsuch_t<T>, Ret>;
 DEF_CONCEPT is_nothrow_exact_dereferenceable_v = is_nothrow_dereferenceable_v<T> && is_exact_dereferenceable_v<T, Ret>;

--- a/include/concepts/operations/is_pointer_to_member_accessable_v.hpp
+++ b/include/concepts/operations/is_pointer_to_member_accessable_v.hpp
@@ -7,55 +7,55 @@
 
 namespace nxwheels {
 template <class T, class P> using pointer_to_data_member_accessed_t = decltype( declval<T>()->*declval<P>() );
-template <class T, class P> constexpr const static inline bool is_pointer_to_data_member_accessable_v = is_detected_v<pointer_to_data_member_accessed_t, T, P>;
+template <class T, class P> CONCEPT_T is_pointer_to_data_member_accessable_v = is_detected_v<pointer_to_data_member_accessed_t, T, P>;
 
 template <class T, class P, class ...Args> using pointer_to_function_member_accessed_t = decltype( (declval<T>()->*declval<P>())(declval<Args>()...) );
 template <class T, class P, class ...Args>
-constexpr const static inline bool __is_pointer_to_function_member_accessable_v = is_detected_v<pointer_to_function_member_accessed_t, T, P, Args...>;
+CONCEPT_T __is_pointer_to_function_member_accessable_v = is_detected_v<pointer_to_function_member_accessed_t, T, P, Args...>;
 template <class T, class P, class ...Args> struct __is_pointer_to_function_member_accessable: bool_constant<__is_pointer_to_function_member_accessable_v<T, P, Args...>> {};
 template <class T, class P>
-constexpr const static inline bool _is_pointer_to_function_member_accessable_v = apply_function_args_to_t<pointed_to_by_member_pointer_t<P>,
-                                                                                                          PARTIAL_APPLY_T(__is_pointer_to_function_member_accessable, T, P)>::value;
+CONCEPT_T _is_pointer_to_function_member_accessable_v = apply_function_args_to_t<pointed_to_by_member_pointer_t<P>,
+                                                                                 PARTIAL_APPLY_T(__is_pointer_to_function_member_accessable, T, P)>::value;
 template <class T, class P>
-constexpr const static inline bool is_pointer_to_function_member_accessable_v = []{
+CONCEPT_T is_pointer_to_function_member_accessable_v = []{
     if constexpr(is_member_function_pointer_v<P>)
         return _is_pointer_to_function_member_accessable_v<T, P>;
     else
         return false;
 }();
 
-template <class T, class P> constexpr const static inline bool _is_nothrow_pointer_to_data_member_accessable_v = noexcept( declval<T>()->*declval<P>() );
+template <class T, class P> CONCEPT_T _is_nothrow_pointer_to_data_member_accessable_v = noexcept( declval<T>()->*declval<P>() );
 template <class T, class P, class ...Args>
-constexpr const static inline bool __is_nothrow_pointer_to_function_member_accessable_v = noexcept( (declval<T>()->*declval<P>())(declval<Args>()...) );
+CONCEPT_T __is_nothrow_pointer_to_function_member_accessable_v = noexcept( (declval<T>()->*declval<P>())(declval<Args>()...) );
 template <class T, class P, class ...Args>
 struct __is_nothrow_pointer_to_function_member_accessable: bool_constant<__is_nothrow_pointer_to_function_member_accessable_v<T, P, Args...>> {};
 
-template <class T, class P> constexpr const static inline bool is_nothrow_pointer_to_data_member_accessable_v = []{
+template <class T, class P> CONCEPT_T is_nothrow_pointer_to_data_member_accessable_v = []{
     if constexpr(is_pointer_to_data_member_accessable_v<T, P>)
         return _is_nothrow_pointer_to_data_member_accessable_v<T, P>;
     else
         return false;
 }();
-template <class T, class P> constexpr const static inline bool _is_nothrow_pointer_to_function_member_accessable_v = []{
+template <class T, class P> CONCEPT_T _is_nothrow_pointer_to_function_member_accessable_v = []{
     if constexpr(_is_pointer_to_function_member_accessable_v<T, P>)
         return apply_function_args_to_t<pointed_to_by_member_pointer_t<P>, PARTIAL_APPLY_T(__is_nothrow_pointer_to_function_member_accessable, T, P)>::value;
     else
         return false;
 }();
-template <class T, class P> constexpr const static inline bool is_nothrow_pointer_to_function_member_accessable_v = []{
+template <class T, class P> CONCEPT_T is_nothrow_pointer_to_function_member_accessable_v = []{
     if constexpr(is_member_function_pointer_v<P>)
         return _is_nothrow_pointer_to_function_member_accessable_v<T, P>;
     else
         return false;
 }();
 
-template <class T, class P> constexpr const static inline bool is_pointer_to_member_accessable_v = []{
+template <class T, class P> CONCEPT_T is_pointer_to_member_accessable_v = []{
     if constexpr(is_member_function_pointer_v<P>)
         return _is_pointer_to_function_member_accessable_v<T, P>;
     else
         return is_pointer_to_data_member_accessable_v<T, P>;
 }();
-template <class T, class P> constexpr const static inline bool is_nothrow_pointer_to_member_accessable_v = []{
+template <class T, class P> CONCEPT_T is_nothrow_pointer_to_member_accessable_v = []{
     if constexpr(is_member_function_pointer_v<P>)
         return _is_nothrow_pointer_to_function_member_accessable_v<T, P>;
     else

--- a/include/concepts/operations/is_self_decrementable_v.hpp
+++ b/include/concepts/operations/is_self_decrementable_v.hpp
@@ -11,17 +11,17 @@ namespace nxwheels {
 DEF_UN_IMP_CONVERT_CHECK(pre_decrement, --, add_lvalue_reference_t<T>);
 
 template <class T> using post_decremented_t = decltype( declval<T>()-- );
-template <class T> constexpr const static inline bool is_post_decrementable_v = is_detected_implicitly_convertible_v<std::remove_reference_t<T>, post_decremented_t, T>;
-template <class T> constexpr const static inline bool _is_nothrow_post_decrementable_v = noexcept( declval<T>()-- );
-template <class T> constexpr const static inline bool is_nothrow_post_decrementable_v = []{
+template <class T> CONCEPT_T is_post_decrementable_v = is_detected_implicitly_convertible_v<std::remove_reference_t<T>, post_decremented_t, T>;
+template <class T> CONCEPT_T _is_nothrow_post_decrementable_v = noexcept( declval<T>()-- );
+template <class T> CONCEPT_T is_nothrow_post_decrementable_v = []{
     if constexpr(is_post_decrementable_v<T>)
         return _is_nothrow_post_decrementable_v<T>;
     else
         return false;
 }();
 
-template <class T> constexpr const static inline bool is_self_decrementable_v = is_pre_decrementable_v<T> && is_post_decrementable_v<T>;
-template <class T> constexpr const static inline bool is_nothrow_self_decrementable_v = is_nothrow_pre_decrementable_v<T> && is_nothrow_post_decrementable_v<T>;
+template <class T> CONCEPT_T is_self_decrementable_v = is_pre_decrementable_v<T> && is_post_decrementable_v<T>;
+template <class T> CONCEPT_T is_nothrow_self_decrementable_v = is_nothrow_pre_decrementable_v<T> && is_nothrow_post_decrementable_v<T>;
 
 DEF_UN_CHECK_T(pre_decrement);
 DEF_UN_CHECK_T(post_decrement);

--- a/include/concepts/operations/is_self_incrementable_v.hpp
+++ b/include/concepts/operations/is_self_incrementable_v.hpp
@@ -11,17 +11,17 @@ namespace nxwheels {
 DEF_UN_IMP_CONVERT_CHECK(pre_increment, ++, add_lvalue_reference_t<T>);
 
 template <class T> using post_incremented_t = decltype( declval<T>()++ );
-template <class T> constexpr const static inline bool is_post_incrementable_v = is_detected_implicitly_convertible_v<std::remove_reference_t<T>, post_incremented_t, T>;
-template <class T> constexpr const static inline bool _is_nothrow_post_incrementable_v = noexcept( declval<T>()++ );
-template <class T> constexpr const static inline bool is_nothrow_post_incrementable_v = [] {
+template <class T> CONCEPT_T is_post_incrementable_v = is_detected_implicitly_convertible_v<std::remove_reference_t<T>, post_incremented_t, T>;
+template <class T> CONCEPT_T _is_nothrow_post_incrementable_v = noexcept( declval<T>()++ );
+template <class T> CONCEPT_T is_nothrow_post_incrementable_v = [] {
     if constexpr(is_post_incrementable_v<T>)
         return _is_nothrow_post_incrementable_v<T>;
     else
         return false;
 }();
 
-template <class T> constexpr const static inline bool is_self_incrementable_v = is_pre_incrementable_v<T> && is_post_incrementable_v<T>;
-template <class T> constexpr const static inline bool is_nothrow_self_incrementable_v = is_nothrow_pre_incrementable_v<T> && is_nothrow_post_incrementable_v<T>;
+template <class T> CONCEPT_T is_self_incrementable_v = is_pre_incrementable_v<T> && is_post_incrementable_v<T>;
+template <class T> CONCEPT_T is_nothrow_self_incrementable_v = is_nothrow_pre_incrementable_v<T> && is_nothrow_post_incrementable_v<T>;
 
 DEF_UN_CHECK_T(pre_increment);
 DEF_UN_CHECK_T(post_increment);

--- a/include/concepts/operations/is_subscriptable_v.hpp
+++ b/include/concepts/operations/is_subscriptable_v.hpp
@@ -6,10 +6,10 @@
 namespace nxwheels {
 template <class T, class Val> using subscripted_t = decltype( declval<T>()[declval<Val>()] );
 
-template <class T, class Val> constexpr const static inline bool is_subscriptable_v = is_detected_v<subscripted_t, T, Val>;
+template <class T, class Val> CONCEPT_T is_subscriptable_v = is_detected_v<subscripted_t, T, Val>;
 
-template <class T, class Val> constexpr const static inline bool _is_nothrow_subscriptable_v = noexcept( declval<T>()[declval<Val>()] );
-template <class T, class Val> constexpr const static inline bool is_nothrow_subscriptable_v = []{
+template <class T, class Val> CONCEPT_T _is_nothrow_subscriptable_v = noexcept( declval<T>()[declval<Val>()] );
+template <class T, class Val> CONCEPT_T is_nothrow_subscriptable_v = []{
     if constexpr(is_subscriptable_v<T, Val>)
         return _is_nothrow_subscriptable_v<T, Val>;
     else

--- a/include/concepts/operations/is_swappable_v.hpp
+++ b/include/concepts/operations/is_swappable_v.hpp
@@ -7,25 +7,25 @@
 
 namespace nxwheels {
 template <class T1, class T2> using swap_ret_t = decltype( swap(declval<T1>(), declval<T2>()) );
-template <class T1, class T2> constexpr const static inline bool is_swappable_with_impl_v = is_detected_v<swap_ret_t, T1, T2>;
+template <class T1, class T2> CONCEPT_T is_swappable_with_impl_v = is_detected_v<swap_ret_t, T1, T2>;
 /*!
  * is_swappable_with_v tests whether in the current context swap(declval<T1>(), declval<T2>()) and swap(declval<T2>(), declval<T1>()) is valid.
  * To test standard-conformant concept swappable, usrs need to #include utility and using std::swap; themselves.
  */
-template <class T1, class T2> constexpr const static inline bool is_swappable_with_v = []{
+template <class T1, class T2> CONCEPT_T is_swappable_with_v = []{
     if constexpr(is_referenceable_v<T1> && is_referenceable_v<T2>)
         return is_swappable_with_impl_v<T1, T2> && is_swappable_with_impl_v<T2, T1>;
     else
         return false;
 }();
 
-template <class T1, class T2> constexpr const static inline bool _is_nothrow_swappable_with_impl_v = noexcept( swap(declval<T1>(), declval<T2>()) );
+template <class T1, class T2> CONCEPT_T _is_nothrow_swappable_with_impl_v = noexcept( swap(declval<T1>(), declval<T2>()) );
 template <class T1, class T2>
 constexpr const static inline bool is_nothrow_swappable_with_impl_v = _is_nothrow_swappable_with_impl_v<T1, T2> && _is_nothrow_swappable_with_impl_v<T2, T1>;
 /*!
  * is_nothrow_swappable_with_v not only tests whether T1 and T2 is swappable, but it also tests whether their swap is non-throwing.
  */
-template <class T1, class T2> constexpr const static inline bool is_nothrow_swappable_with_v = []{
+template <class T1, class T2> CONCEPT_T is_nothrow_swappable_with_v = []{
     if constexpr(is_swappable_with_v<T1, T2>)
         return is_nothrow_swappable_with_impl_v<T1, T2>;
     else
@@ -35,7 +35,7 @@ template <class T1, class T2> constexpr const static inline bool is_nothrow_swap
 /*!
  * is_swappable_v<T> == is_swappable_with_v<T, T>
  */
-template <class T> constexpr const static inline bool is_swappable_v = []{
+template <class T> CONCEPT_T is_swappable_v = []{
     if constexpr(is_referenceable_v<T>)
         return is_swappable_with_impl_v<T, T>;
     else
@@ -44,7 +44,7 @@ template <class T> constexpr const static inline bool is_swappable_v = []{
 /*!
  * is_nothrow_swappable_v<T> == is_nothrow_swappable_with_v<T, T>
  */
-template <class T> constexpr const static inline bool is_nothrow_swappable_v = []{
+template <class T> CONCEPT_T is_nothrow_swappable_v = []{
     if constexpr(is_swappable_v<T>)
         return _is_nothrow_swappable_with_impl_v<T, T>;
     else

--- a/include/concepts/operations/undef_convenient_macros.hpp
+++ b/include/concepts/operations/undef_convenient_macros.hpp
@@ -1,3 +1,5 @@
+#include "../../undef_convenient_macros.hpp"
+
 #ifdef DEF_UN_CHECK
 # undef DEF_UN_CHECK
 #endif

--- a/include/concepts/undef_convenient_macros.hpp
+++ b/include/concepts/undef_convenient_macros.hpp
@@ -1,6 +1,4 @@
-#ifdef VAR
-# undef VAR
-#endif
+#include "../undef_convenient_macros.hpp"
 
 #ifdef TP1
 # undef TP1

--- a/include/def_convenient_macros.hpp
+++ b/include/def_convenient_macros.hpp
@@ -1,0 +1,7 @@
+#ifndef   CONCEPT_T
+# if   __cplusplus == 201703L
+#  define CONCEPT_T constexpr const static inline
+# elif __cplusplus == 201402L
+#  define CONCEPT_T constexpr const static
+# endif
+#endif

--- a/include/def_convenient_macros.hpp
+++ b/include/def_convenient_macros.hpp
@@ -1,0 +1,11 @@
+#ifndef   CONSTEXPR_GLOBAL_VAR
+# if   __cplusplus == 201703L
+#  define CONSTEXPR_GLOBAL_VAR constexpr const static inline
+# elif __cplusplus == 201402L
+#  define CONSTEXPR_GLOBAL_VAR constexpr const static
+# endif
+#endif
+
+#ifndef  CONCEPT_T
+# define CONCEPT_T CONSTEXPR_GLOBAL_VAR bool
+#endif

--- a/include/def_convenient_macros.hpp
+++ b/include/def_convenient_macros.hpp
@@ -1,7 +1,0 @@
-#ifndef   CONCEPT_T
-# if   __cplusplus == 201703L
-#  define CONCEPT_T constexpr const static inline
-# elif __cplusplus == 201402L
-#  define CONCEPT_T constexpr const static
-# endif
-#endif

--- a/include/detector_v.hpp
+++ b/include/detector_v.hpp
@@ -4,8 +4,13 @@
 # include "detector_core.hpp"
 # include "concepts/operations/is_convertible_v.hpp"
 
+# include "def_convenient_macros.hpp"
+
 namespace nxwheels {
 template <class To, template <class...> class op, class ...Ts>
-constexpr const static inline bool is_detected_implicitly_convertible_v = is_implicitly_convertible_v<detected_t<op, Ts...>, To>;
+CONCEPT_T is_detected_implicitly_convertible_v = is_implicitly_convertible_v<detected_t<op, Ts...>, To>;
 } /* nxwheels */
+
+# include "undef_convenient_macros.hpp"
+
 #endif

--- a/include/function_traits.hpp
+++ b/include/function_traits.hpp
@@ -1,20 +1,22 @@
 #ifndef __nobodyxu_concept_check_function_traits_HPP__
 # define __nobodyxu_concept_check_function_traits_HPP__
 
+# include "def_convenient_macros.hpp"
+
 namespace nxwheels {
 template <class ...Args> struct Argslist {};
 
 template <class T>
 struct function_traits {
-    constexpr const static inline bool is_function_v = false;
+    CONCEPT_T is_function_v = false;
 
-    constexpr const static inline bool is_const_qualified_v = false;
-    constexpr const static inline bool is_volatile_qualified_v = false;
-    constexpr const static inline bool is_lvalue_reference_qualified_v = false;
-    constexpr const static inline bool is_rvalue_reference_qualified_v = false;
-    constexpr const static inline bool is_cvref_qualified_v = false;
+    CONCEPT_T is_const_qualified_v = false;
+    CONCEPT_T is_volatile_qualified_v = false;
+    CONCEPT_T is_lvalue_reference_qualified_v = false;
+    CONCEPT_T is_rvalue_reference_qualified_v = false;
+    CONCEPT_T is_cvref_qualified_v = false;
 
-    constexpr const static inline bool is_noexcept_qualified_v = false;
+    CONCEPT_T is_noexcept_qualified_v = false;
 };
 
 # define DEF_ARG_OP()\
@@ -25,15 +27,15 @@ struct function_traits {
 // The basic scenrio.
 template <class R, class ...Args, bool is_noexcept>
 struct function_traits<R (Args...) noexcept(is_noexcept)> {
-    constexpr const static inline bool is_function_v = true;
+    CONCEPT_T is_function_v = true;
 
-    constexpr const static inline bool is_const_qualified_v = false;
-    constexpr const static inline bool is_volatile_qualified_v = false;
-    constexpr const static inline bool is_lvalue_reference_qualified_v = false;
-    constexpr const static inline bool is_rvalue_reference_qualified_v = false;
-    constexpr const static inline bool is_cvref_qualified_v = false;
+    CONCEPT_T is_const_qualified_v = false;
+    CONCEPT_T is_volatile_qualified_v = false;
+    CONCEPT_T is_lvalue_reference_qualified_v = false;
+    CONCEPT_T is_rvalue_reference_qualified_v = false;
+    CONCEPT_T is_cvref_qualified_v = false;
 
-    constexpr const static inline bool is_noexcept_qualified_v = is_noexcept;
+    CONCEPT_T is_noexcept_qualified_v = is_noexcept;
 
     DEF_ARG_OP();
     using ret_t = R;
@@ -44,15 +46,15 @@ struct function_traits<R (Args...) noexcept(is_noexcept)> {
 // const volatile & &&
 template <class R, class ...Args, bool is_noexcept_v>
 struct function_traits<R (Args...) const noexcept(is_noexcept_v)> {
-    constexpr const static inline bool is_function_v = true;
+    CONCEPT_T is_function_v = true;
 
-    constexpr const static inline bool is_const_qualified_v = true;
-    constexpr const static inline bool is_volatile_qualified_v = false;
-    constexpr const static inline bool is_lvalue_reference_qualified_v = false;
-    constexpr const static inline bool is_rvalue_reference_qualified_v = false;
-    constexpr const static inline bool is_cvref_qualified_v = true;
+    CONCEPT_T is_const_qualified_v = true;
+    CONCEPT_T is_volatile_qualified_v = false;
+    CONCEPT_T is_lvalue_reference_qualified_v = false;
+    CONCEPT_T is_rvalue_reference_qualified_v = false;
+    CONCEPT_T is_cvref_qualified_v = true;
 
-    constexpr const static inline bool is_noexcept_qualified_v = is_noexcept_v;
+    CONCEPT_T is_noexcept_qualified_v = is_noexcept_v;
 
     DEF_ARG_OP();
     using ret_t = R;
@@ -60,15 +62,15 @@ struct function_traits<R (Args...) const noexcept(is_noexcept_v)> {
 };
 template <class R, class ...Args, bool is_noexcept_v>
 struct function_traits<R (Args...) const & noexcept(is_noexcept_v)> {
-    constexpr const static inline bool is_function_v = true;
+    CONCEPT_T is_function_v = true;
 
-    constexpr const static inline bool is_const_qualified_v = true;
-    constexpr const static inline bool is_volatile_qualified_v = false;
-    constexpr const static inline bool is_lvalue_reference_qualified_v = true;
-    constexpr const static inline bool is_rvalue_reference_qualified_v = false;
-    constexpr const static inline bool is_cvref_qualified_v = true;
+    CONCEPT_T is_const_qualified_v = true;
+    CONCEPT_T is_volatile_qualified_v = false;
+    CONCEPT_T is_lvalue_reference_qualified_v = true;
+    CONCEPT_T is_rvalue_reference_qualified_v = false;
+    CONCEPT_T is_cvref_qualified_v = true;
 
-    constexpr const static inline bool is_noexcept_qualified_v = is_noexcept_v;
+    CONCEPT_T is_noexcept_qualified_v = is_noexcept_v;
 
     DEF_ARG_OP();
     using ret_t = R;
@@ -76,15 +78,15 @@ struct function_traits<R (Args...) const & noexcept(is_noexcept_v)> {
 };
 template <class R, class ...Args, bool is_noexcept_v>
 struct function_traits<R (Args...) const && noexcept(is_noexcept_v)> {
-    constexpr const static inline bool is_function_v = true;
+    CONCEPT_T is_function_v = true;
 
-    constexpr const static inline bool is_const_qualified_v = true;
-    constexpr const static inline bool is_volatile_qualified_v = false;
-    constexpr const static inline bool is_lvalue_reference_qualified_v = false;
-    constexpr const static inline bool is_rvalue_reference_qualified_v = true;
-    constexpr const static inline bool is_cvref_qualified_v = true;
+    CONCEPT_T is_const_qualified_v = true;
+    CONCEPT_T is_volatile_qualified_v = false;
+    CONCEPT_T is_lvalue_reference_qualified_v = false;
+    CONCEPT_T is_rvalue_reference_qualified_v = true;
+    CONCEPT_T is_cvref_qualified_v = true;
 
-    constexpr const static inline bool is_noexcept_qualified_v = is_noexcept_v;
+    CONCEPT_T is_noexcept_qualified_v = is_noexcept_v;
 
     DEF_ARG_OP();
     using ret_t = R;
@@ -93,15 +95,15 @@ struct function_traits<R (Args...) const && noexcept(is_noexcept_v)> {
 
 template <class R, class ...Args, bool is_noexcept_v>
 struct function_traits<R (Args...) volatile noexcept(is_noexcept_v)> {
-    constexpr const static inline bool is_function_v = true;
+    CONCEPT_T is_function_v = true;
 
-    constexpr const static inline bool is_const_qualified_v = false;
-    constexpr const static inline bool is_volatile_qualified_v = true;
-    constexpr const static inline bool is_lvalue_reference_qualified_v = false;
-    constexpr const static inline bool is_rvalue_reference_qualified_v = false;
-    constexpr const static inline bool is_cvref_qualified_v = true;
+    CONCEPT_T is_const_qualified_v = false;
+    CONCEPT_T is_volatile_qualified_v = true;
+    CONCEPT_T is_lvalue_reference_qualified_v = false;
+    CONCEPT_T is_rvalue_reference_qualified_v = false;
+    CONCEPT_T is_cvref_qualified_v = true;
 
-    constexpr const static inline bool is_noexcept_qualified_v = is_noexcept_v;
+    CONCEPT_T is_noexcept_qualified_v = is_noexcept_v;
 
     DEF_ARG_OP();
     using ret_t = R;
@@ -109,15 +111,15 @@ struct function_traits<R (Args...) volatile noexcept(is_noexcept_v)> {
 };
 template <class R, class ...Args, bool is_noexcept_v>
 struct function_traits<R (Args...) volatile & noexcept(is_noexcept_v)> {
-    constexpr const static inline bool is_function_v = true;
+    CONCEPT_T is_function_v = true;
 
-    constexpr const static inline bool is_const_qualified_v = false;
-    constexpr const static inline bool is_volatile_qualified_v = true;
-    constexpr const static inline bool is_lvalue_reference_qualified_v = true;
-    constexpr const static inline bool is_rvalue_reference_qualified_v = false;
-    constexpr const static inline bool is_cvref_qualified_v = true;
+    CONCEPT_T is_const_qualified_v = false;
+    CONCEPT_T is_volatile_qualified_v = true;
+    CONCEPT_T is_lvalue_reference_qualified_v = true;
+    CONCEPT_T is_rvalue_reference_qualified_v = false;
+    CONCEPT_T is_cvref_qualified_v = true;
 
-    constexpr const static inline bool is_noexcept_qualified_v = is_noexcept_v;
+    CONCEPT_T is_noexcept_qualified_v = is_noexcept_v;
 
     DEF_ARG_OP();
     using ret_t = R;
@@ -125,15 +127,15 @@ struct function_traits<R (Args...) volatile & noexcept(is_noexcept_v)> {
 };
 template <class R, class ...Args, bool is_noexcept_v>
 struct function_traits<R (Args...) volatile && noexcept(is_noexcept_v)> {
-    constexpr const static inline bool is_function_v = true;
+    CONCEPT_T is_function_v = true;
 
-    constexpr const static inline bool is_const_qualified_v = false;
-    constexpr const static inline bool is_volatile_qualified_v = true;
-    constexpr const static inline bool is_lvalue_reference_qualified_v = false;
-    constexpr const static inline bool is_rvalue_reference_qualified_v = true;
-    constexpr const static inline bool is_cvref_qualified_v = true;
+    CONCEPT_T is_const_qualified_v = false;
+    CONCEPT_T is_volatile_qualified_v = true;
+    CONCEPT_T is_lvalue_reference_qualified_v = false;
+    CONCEPT_T is_rvalue_reference_qualified_v = true;
+    CONCEPT_T is_cvref_qualified_v = true;
 
-    constexpr const static inline bool is_noexcept_qualified_v = is_noexcept_v;
+    CONCEPT_T is_noexcept_qualified_v = is_noexcept_v;
 
     DEF_ARG_OP();
     using ret_t = R;
@@ -142,15 +144,15 @@ struct function_traits<R (Args...) volatile && noexcept(is_noexcept_v)> {
 
 template <class R, class ...Args, bool is_noexcept_v>
 struct function_traits<R (Args...) & noexcept(is_noexcept_v)> {
-    constexpr const static inline bool is_function_v = true;
+    CONCEPT_T is_function_v = true;
 
-    constexpr const static inline bool is_const_qualified_v = false;
-    constexpr const static inline bool is_volatile_qualified_v = false;
-    constexpr const static inline bool is_lvalue_reference_qualified_v = true;
-    constexpr const static inline bool is_rvalue_reference_qualified_v = false;
-    constexpr const static inline bool is_cvref_qualified_v = true;
+    CONCEPT_T is_const_qualified_v = false;
+    CONCEPT_T is_volatile_qualified_v = false;
+    CONCEPT_T is_lvalue_reference_qualified_v = true;
+    CONCEPT_T is_rvalue_reference_qualified_v = false;
+    CONCEPT_T is_cvref_qualified_v = true;
 
-    constexpr const static inline bool is_noexcept_qualified_v = is_noexcept_v;
+    CONCEPT_T is_noexcept_qualified_v = is_noexcept_v;
 
     DEF_ARG_OP();
     using ret_t = R;
@@ -158,15 +160,15 @@ struct function_traits<R (Args...) & noexcept(is_noexcept_v)> {
 };
 template <class R, class ...Args, bool is_noexcept_v>
 struct function_traits<R (Args...) && noexcept(is_noexcept_v)> {
-    constexpr const static inline bool is_function_v = true;
+    CONCEPT_T is_function_v = true;
 
-    constexpr const static inline bool is_const_qualified_v = false;
-    constexpr const static inline bool is_volatile_qualified_v = false;
-    constexpr const static inline bool is_lvalue_reference_qualified_v = false;
-    constexpr const static inline bool is_rvalue_reference_qualified_v = true;
-    constexpr const static inline bool is_cvref_qualified_v = true;
+    CONCEPT_T is_const_qualified_v = false;
+    CONCEPT_T is_volatile_qualified_v = false;
+    CONCEPT_T is_lvalue_reference_qualified_v = false;
+    CONCEPT_T is_rvalue_reference_qualified_v = true;
+    CONCEPT_T is_cvref_qualified_v = true;
 
-    constexpr const static inline bool is_noexcept_qualified_v = is_noexcept_v;
+    CONCEPT_T is_noexcept_qualified_v = is_noexcept_v;
 
     DEF_ARG_OP();
     using ret_t = R;
@@ -175,15 +177,15 @@ struct function_traits<R (Args...) && noexcept(is_noexcept_v)> {
 
 template <class R, class ...Args, bool is_noexcept_v>
 struct function_traits<R (Args...) const volatile noexcept(is_noexcept_v)> {
-    constexpr const static inline bool is_function_v = true;
+    CONCEPT_T is_function_v = true;
 
-    constexpr const static inline bool is_const_qualified_v = true;
-    constexpr const static inline bool is_volatile_qualified_v = true;
-    constexpr const static inline bool is_lvalue_reference_qualified_v = false;
-    constexpr const static inline bool is_rvalue_reference_qualified_v = false;
-    constexpr const static inline bool is_cvref_qualified_v = true;
+    CONCEPT_T is_const_qualified_v = true;
+    CONCEPT_T is_volatile_qualified_v = true;
+    CONCEPT_T is_lvalue_reference_qualified_v = false;
+    CONCEPT_T is_rvalue_reference_qualified_v = false;
+    CONCEPT_T is_cvref_qualified_v = true;
 
-    constexpr const static inline bool is_noexcept_qualified_v = is_noexcept_v;
+    CONCEPT_T is_noexcept_qualified_v = is_noexcept_v;
 
     DEF_ARG_OP();
     using ret_t = R;
@@ -191,15 +193,15 @@ struct function_traits<R (Args...) const volatile noexcept(is_noexcept_v)> {
 };
 template <class R, class ...Args, bool is_noexcept_v>
 struct function_traits<R (Args...) const volatile & noexcept(is_noexcept_v)> {
-    constexpr const static inline bool is_function_v = true;
+    CONCEPT_T is_function_v = true;
 
-    constexpr const static inline bool is_const_qualified_v = true;
-    constexpr const static inline bool is_volatile_qualified_v = true;
-    constexpr const static inline bool is_lvalue_reference_qualified_v = true;
-    constexpr const static inline bool is_rvalue_reference_qualified_v = false;
-    constexpr const static inline bool is_cvref_qualified_v = true;
+    CONCEPT_T is_const_qualified_v = true;
+    CONCEPT_T is_volatile_qualified_v = true;
+    CONCEPT_T is_lvalue_reference_qualified_v = true;
+    CONCEPT_T is_rvalue_reference_qualified_v = false;
+    CONCEPT_T is_cvref_qualified_v = true;
 
-    constexpr const static inline bool is_noexcept_qualified_v = is_noexcept_v;
+    CONCEPT_T is_noexcept_qualified_v = is_noexcept_v;
 
     DEF_ARG_OP();
     using ret_t = R;
@@ -207,15 +209,15 @@ struct function_traits<R (Args...) const volatile & noexcept(is_noexcept_v)> {
 };
 template <class R, class ...Args, bool is_noexcept_v>
 struct function_traits<R (Args...) const volatile && noexcept(is_noexcept_v)> {
-    constexpr const static inline bool is_function_v = true;
+    CONCEPT_T is_function_v = true;
 
-    constexpr const static inline bool is_const_qualified_v = true;
-    constexpr const static inline bool is_volatile_qualified_v = true;
-    constexpr const static inline bool is_lvalue_reference_qualified_v = false;
-    constexpr const static inline bool is_rvalue_reference_qualified_v = true;
-    constexpr const static inline bool is_cvref_qualified_v = true;
+    CONCEPT_T is_const_qualified_v = true;
+    CONCEPT_T is_volatile_qualified_v = true;
+    CONCEPT_T is_lvalue_reference_qualified_v = false;
+    CONCEPT_T is_rvalue_reference_qualified_v = true;
+    CONCEPT_T is_cvref_qualified_v = true;
 
-    constexpr const static inline bool is_noexcept_qualified_v = is_noexcept_v;
+    CONCEPT_T is_noexcept_qualified_v = is_noexcept_v;
 
     DEF_ARG_OP();
     using ret_t = R;
@@ -233,4 +235,7 @@ template <class T, template <class...> class Op> using apply_function_args_to_t 
 
 template <class T> using ret_t_of_function = typename function_traits<T>::ret_t;
 } /* nxwheels */
+
+# include "undef_convenient_macros.hpp"
+
 #endif

--- a/include/undef_convenient_macros.hpp
+++ b/include/undef_convenient_macros.hpp
@@ -1,0 +1,3 @@
+#ifdef  CONCEPT_T
+# undef CONCEPT_T
+#endif

--- a/include/undef_convenient_macros.hpp
+++ b/include/undef_convenient_macros.hpp
@@ -1,3 +1,0 @@
-#ifdef  CONCEPT_T
-# undef CONCEPT_T
-#endif

--- a/include/undef_convenient_macros.hpp
+++ b/include/undef_convenient_macros.hpp
@@ -1,0 +1,7 @@
+#ifdef  CONSTEXPR_GLOBAL_VAR
+# undef CONSTEXPR_GLOBAL_VAR
+#endif
+
+#ifdef  CONCEPT_T
+# undef CONCEPT_T
+#endif


### PR DESCRIPTION
Use CONCEPT_T instead of ```constexpr const static inline bool``` to make changing the specifier of concepts easier.