### PR TITLE
Add more test cases for concepts/is_iterator_v.hpp

### DIFF
--- a/include/concepts/has_valid_iterator_traits_v.hpp
+++ b/include/concepts/has_valid_iterator_traits_v.hpp
@@ -9,6 +9,7 @@
 
 # include "is_nullable_pointer_v.hpp"
 # include "is_arithmetic_v.hpp"
+# include "is_same.hpp"
 
 # include "def_convenient_macros.hpp"
 
@@ -17,13 +18,15 @@ namespace nxwheels {
 
 template <class T>
 CONCEPT_T has_valid_iterator_traits_v = []{
-    if constexpr(has_member_type_value_type_v<std::iterator_traits<T>>)
-        return !std::is_void              <TRAITS(value_type)>{}()                &&
-               is_implicitly_convertible_v<TRAITS(reference), TRAITS(value_type)> &&
-               is_nullable_pointer_v      <TRAITS(pointer)>                       &&
-               is_arithmetic_v            <TRAITS(difference_type)>               &&
-               std::is_base_of            <std::input_iterator_tag, TRAITS(iterator_category)>{}();
-    else
+    if constexpr(has_member_type_value_type_v<std::iterator_traits<T>>) {
+        if constexpr(!is_same_v<TRAITS(value_type), void>)
+               return is_implicitly_convertible_v<TRAITS(reference), TRAITS(value_type)> &&
+                      is_nullable_pointer_v      <TRAITS(pointer)>                       &&
+                      is_arithmetic_v            <TRAITS(difference_type)>               &&
+                      std::is_base_of            <std::input_iterator_tag, TRAITS(iterator_category)>{}();
+        else
+            return false;
+    } else
         return false;
 }();
 

--- a/include/concepts/is_iterator_core.hpp
+++ b/include/concepts/is_iterator_core.hpp
@@ -46,9 +46,12 @@ CONCEPT_T is_RandomAccessIterator_core_impl_other_req_v = /* arithmetic op requi
                                                           is_raw_subtractionable_v<T, diff_t>                            &&
                                                           is_raw_subtractionable_v<T, T, diff_t>                         &&
                                                           /* access requirement */
-                                                          is_subscriptable_v<T, diff_t>                              &&
-                                                          /* convertion requirement */
-                                                          is_implicitly_convertible_v<subscripted_ret_t<T, diff_t>, ref>;
+                                                          []{
+                                                              if constexpr(is_subscriptable_v<T, diff_t>)
+                                                                  return is_implicitly_convertible_v<subscripted_ret_t<T, diff_t>, ref>;
+                                                              else
+                                                                  return false;
+                                                          }();
 
 # define TRAITS(NAME) typename std::iterator_traits<T>:: NAME
 

--- a/test/concepts/test_is_iterator_v.cc
+++ b/test/concepts/test_is_iterator_v.cc
@@ -9,30 +9,49 @@
 using namespace nxwheels;
 
 int main() {
+    using InputIterator_t  = std::istream_iterator<int>;
+    using OutputIterator_t = std::back_insert_iterator<std::vector<int>>;
+
+    using const_ForwardIterator_t   = decltype(std::forward_list<int>().cbegin());
+    using mutable_ForwardIterator_t = decltype(std::forward_list<int>().begin());
+
+    using const_BidirectionalIterator_t   = decltype(std::list<int>().cbegin());
+    using mutable_BidirectionalIterator_t = decltype(std::list<int>().begin());
+
     static_assert(!is_Iterator_v<int>);
-    static_assert(!is_RandomAccessIterator_v<int>);
 
     // Input Iterator
-    static_assert(is_InputIterator_v<std::istream_iterator<int>>);
+    static_assert(is_InputIterator_v<InputIterator_t>);
 
     // Output Iterator
-    static_assert(is_Iterator_v<std::back_insert_iterator<std::vector<int>>>);
+    static_assert(is_Iterator_v<OutputIterator_t>);
 
     // Forward Iterator
-    static_assert(is_mutable_ForwardIterator_v<decltype(std::forward_list<int>().begin())>);
-    static_assert(is_const_ForwardIterator_v<decltype(std::forward_list<int>().cbegin())>);
+    {
+        static_assert(!is_ForwardIterator_v<InputIterator_t>);
+        static_assert(!is_ForwardIterator_v<OutputIterator_t>);
+
+        static_assert(is_mutable_ForwardIterator_v<mutable_ForwardIterator_t>);
+        static_assert(is_const_ForwardIterator_v<const_ForwardIterator_t>);
+    }
 
     // Bidirectional Iterator
-    static_assert(is_mutable_BidirectionalIterator_v<decltype(std::list<int>().begin())>);
-    static_assert(is_const_BidirectionalIterator_v<decltype(std::list<int>().cbegin())>);
+    {
+        static_assert(!is_BidirectionalIterator_v<mutable_ForwardIterator_t>);
+
+        static_assert(is_mutable_BidirectionalIterator_v<mutable_BidirectionalIterator_t>);
+        static_assert(is_const_BidirectionalIterator_v<const_BidirectionalIterator_t>);
+    }
 
     // Random Access Iterator
-    static_assert(is_mutable_RandomAccessIterator_v<int*>);
-    static_assert(is_const_RandomAccessIterator_v<const int*>);
+    {
+        static_assert(!is_RandomAccessIterator_v<int>);
+        static_assert(!is_RandomAccessIterator_v<mutable_BidirectionalIterator_t>);
 
-    static_assert(is_mutable_RandomAccessIterator_v<decltype(std::array<int, 10>().begin())>);
-    static_assert(is_const_RandomAccessIterator_v<decltype(std::array<int, 10>().cbegin())>);
+        static_assert(is_mutable_RandomAccessIterator_v<int*>);
+        static_assert(is_const_RandomAccessIterator_v<const int*>);
 
-    static_assert(is_mutable_RandomAccessIterator_v<decltype(std::vector<int>().begin())>);
-    static_assert(is_const_RandomAccessIterator_v<decltype(std::vector<int>().cbegin())>);
+        static_assert(is_mutable_RandomAccessIterator_v<decltype(std::vector<int>().begin())>);
+        static_assert(is_const_RandomAccessIterator_v<decltype(std::vector<int>().cbegin())>);
+    }
 }


### PR DESCRIPTION
Add more test cases for ```concepts/is_iterator_v.hpp```.

This lead to the expose and the fix of instantiation error in ```concepts/has_valid_iterator_traits_v.hpp``` and ```concepts/is_iterator_core_v.hpp```.